### PR TITLE
add freifunk nord (ffnord) community

### DIFF
--- a/nord
+++ b/nord
@@ -1,0 +1,12 @@
+tech-c:
+  - backend@hamburg.freifunk.net
+asn: 65187
+networks:
+  ipv4:
+    - 10.187.0.0/16
+domains:
+  - ffnord
+  - 187.10.in-addr.arpa
+nameservers:
+  - 10.112.1.1
+  - 2a03:2267::101


### PR DESCRIPTION
ffnord will be a community run by kiel, hamburg and lübeck to kickstart communities in rural areas in the north and to reduce mesh sizes in the cities by migrating nodes outside of the cities to this new community.