### PR TITLE
~Wuppertal, +Solingen, +Gelsenkirchen

### DIFF
--- a/gelsenkirchen
+++ b/gelsenkirchen
@@ -1,0 +1,16 @@
+tech-c:
+  - phip@devtal.de
+asn: 65397
+networks:
+  ipv4:
+    - 10.28.0.0/16
+  ipv6:
+    - fda0:747e:ab29:209::/64
+domains:
+  - ffsg
+  - 28.10.in-addr.arpa
+  - 9.0.2.0.9.2.b.a.e.7.4.7.0.a.d.f.ip6.arpa
+nameservers:
+  - 10.28.0.247
+  - fda0:747e:ab29:209:ff07::1
+

--- a/solingen
+++ b/solingen
@@ -1,0 +1,16 @@
+tech-c:
+  - phip@devtal.de
+asn: 65399
+networks:
+  ipv4:
+    - 10.6.0.0/16
+  ipv6:
+    - fda0:747e:ab29:212::/64
+domains:
+  - ffsg
+  - 6.10.in-addr.arpa
+  - 2.1.2.0.9.2.b.a.e.7.4.7.0.a.d.f.ip6.arpa
+nameservers:
+  - 10.6.0.247
+  - fda0:747e:ab29:212:ff07::1
+

--- a/wuppertal
+++ b/wuppertal
@@ -1,5 +1,5 @@
 tech-c:
-  - felix@devtal.de
+  - phip@devtal.de
 asn: 65523
 networks:
   ipv4:
@@ -12,4 +12,12 @@ bgp:
     ipv6: fec0::a:cf:0:71
 domains:
   - ffw
-# FIXME: Nameserver eintragen
+  - 3.10.in-addr.arpa
+  - a.b.1.e.9.2.b.a.e.7.4.7.0.a.d.f.ip6.arpa
+nameservers:
+  - 10.3.0.247
+  - 10.3.0.249
+  - 10.3.0.250
+  - 10.3.0.251
+  - fda0:747e:ab29:e1ba:ff07::1
+


### PR DESCRIPTION
Hallo zusammen

Das DNS im Tal wurde angepasst.
Anfragen aus FF-Gemeinschaften in Solingen und Gelsenkirchen nach technischer Unterstützung, die von der Domäne Wupper des Freifunk Rheinland e. V. übernommen wird.