### PR TITLE
dropping domain ffwk

### DIFF
--- a/vfnnrw
+++ b/vfnnrw
@@ -43,6 +43,5 @@ bgp:
     ipv4: 10.207.66.66
     ipv6: fec0::a:cf:42:42
 domains:
-  - ffwk
   - ffgro
 # FIXME: Nameserver eintragen


### PR DESCRIPTION
We are dropping the Domain ffwk in favor of FF-Westkueste as discussed on WCW 2015.
solves https://github.com/freifunk/icvpn-meta/issues/145