### PR TITLE
Gelsenkirchen: add TLD

### DIFF
--- a/gelsenkirchen
+++ b/gelsenkirchen
@@ -7,6 +7,7 @@ networks:
   ipv6:
     - fda0:747e:ab29:209::/64
 domains:
+  - ffge
   - 28.10.in-addr.arpa
   - 9.0.2.0.9.2.b.a.e.7.4.7.0.a.d.f.ip6.arpa
 nameservers:


### PR DESCRIPTION
https://github.com/mweinelt war so nett die inkorrekte TLD zu entfernen … hiermit wird die richtige TLD für Gelsenkirchen nachgeliefert 