### PR TITLE
Rheinufer Subdomains added: bucht, ddorf, neuss, tiefland

### DIFF
--- a/bucht
+++ b/bucht
@@ -1,0 +1,8 @@
+tech-c:
+  - nomaster@nomaster.cc
+asn: 64859
+networks:
+  ipv4:
+    - 10.39.0.0/16
+  ipv6:
+    - 2a03:2260:39::/48

--- a/ddorf
+++ b/ddorf
@@ -1,0 +1,8 @@
+tech-c:
+  - nomaster@nomaster.cc
+asn: 64856
+networks:
+  ipv4:
+    - 10.25.0.0/16
+  ipv6:
+    - 2a03:2260:25::/48

--- a/neuss
+++ b/neuss
@@ -1,0 +1,8 @@
+tech-c:
+  - nomaster@nomaster.cc
+asn: 64857
+networks:
+  ipv4:
+    - 10.30.0.0/16
+  ipv6:
+    - 2a03:2260:30::/48

--- a/tiefland
+++ b/tiefland
@@ -1,0 +1,8 @@
+tech-c:
+  - nomaster@nomaster.cc
+asn: 64858
+networks:
+  ipv4:
+    - 10.34.0.0/16
+  ipv6:
+    - 2a03:2260:34::/48


### PR DESCRIPTION
Wir splitten und brauchen neue Netze. Nach der Migration geben wir die Nummern von Rheinufer zurück.