### PR TITLE
Add file for the initial setup of Celle network for Freifunk.

### DIFF
--- a/celle
+++ b/celle
@@ -1,0 +1,12 @@
+tech-c:
+  - info@freifunk-celle.de
+networks:
+  ipv4:
+    - 10.252.0.0/18
+  ipv6:
+    - fd92:2dff:d232::/64
+domains:
+  - freifunk-celle.de
+nameservers:
+  - 10.252.0.1
+  - fd92:2dff:d232::1


### PR DESCRIPTION
This is the initial network reservation for the (AFAIK) first public Freifunk nodes within their own infrastructure in Celle, Lower Saxony, Germany. Please add to the table.