### PR TITLE
update ansprechpartner, community-name

### DIFF
--- a/koblenz
+++ b/koblenz
@@ -1,6 +1,0 @@
-tech-c:
-  - simonmail@gmx.de
-asn: 65032
-networks:
-  ipv4:
-    - 10.222.0.0/16

--- a/mayen-koblenz-westerwald
+++ b/mayen-koblenz-westerwald
@@ -1,0 +1,7 @@
+tech-c:
+  - freifunk@ansgartaflinski.de
+  - freifunk@adlerweb.info
+asn: 65032
+networks:
+  ipv4:
+    - 10.222.0.0/16


### PR DESCRIPTION
der bisher eingetragene tech-c ist nicht kontaktierbar. Freifunk-MYK (Mayen-Koblenz, freifunk-myk.de) ist seit Ende 2014 neu gegründet aktiv und hat mittlerweile rund 90 Router. Als tech-c habe ich die derzeitigen supernode-betreiber eingetragen. Seit September 2015 ist auch Freifunk-Westerwald angeschlossen.