### PR TITLE
Update network range for Celle to allow subnetting.

### DIFF
--- a/celle
+++ b/celle
@@ -4,7 +4,7 @@ networks:
   ipv4:
     - 10.252.0.0/18
   ipv6:
-    - fd92:2dff:d232::/64
+    - fd92:2dff:d232::/48
 domains:
   - freifunk-celle.de
 nameservers:


### PR DESCRIPTION
Celle requires a larger network for v6 due to an outside allocation. The corresponding change only implements the current reservation strategy for IPv6 with alotting at least a /48 for providers.