### PR TITLE
Update ICVPN with public IPv6 network for Freifunk

### DIFF
--- a/celle
+++ b/celle
@@ -6,6 +6,7 @@ networks:
     - 10.252.0.0/18
   ipv6:
     - fd92:2dff:d232::/48
+    - 2001:470:743f::/48
 domains:
   - freifunk-celle.de
   - 0.252.10.in-addr.arpa
@@ -73,6 +74,8 @@ domains:
   - 62.252.10.in-addr.arpa
   - 63.252.10.in-addr.arpa
   - 2.3.2.d.f.f.d.2.2.9.d.f.ip6.arpa
+  - f.3.4.7.0.7.4.0.1.0.0.2.ip6.arpa
 nameservers:
   - 10.252.0.1
   - fd92:2dff:d232::1
+  - 2001:470:743f::1


### PR DESCRIPTION
Add the public IPv6 networks assigned for Freifunk Celle to the ICVPN descriptor file.