### PR TITLE
Create ffruhr

### DIFF
--- a/ffruhr
+++ b/ffruhr
@@ -1,0 +1,3 @@
+asn: 64878
+tech-c:
+  - kontakt@freifunk-ruhrgebiet.de


### PR DESCRIPTION
Das #ruhrgebiet  ist inzwischen so groß geworden das wir freifunk nodes die sich noch in der Ruhrgebiet Infrastruktur befinden in eine reine nodes Infrastruktur überführen.
Dafür benötigen wir eine neue AS Nummer.
Das alte Ruhrgebietsnetz wird dementsprechend nur noch als Backbone Netz für die Bestehenden Subcommunities dienen.