### PR TITLE
Neue Communities: Mettmann, Ratingen, Velbert, Heiligenhaus

### DIFF
--- a/heiligenhaus
+++ b/heiligenhaus
@@ -1,0 +1,11 @@
+# This is your ASN.
+asn: 64871
+tech-c:
+  - freifunk@benedikt-wildenhain.de
+  - mail@stephan-plarre.de
+  - nic@neanderfunk.de
+networks:
+  ipv4:
+    - 10.11.112.0/20
+  ipv6:
+    - fdfc:ba7c:0ca1::/48

--- a/mettmann
+++ b/mettmann
@@ -1,0 +1,11 @@
+# This is your ASN.
+asn: 64863
+tech-c:
+  - freifunk@benedikt-wildenhain.de
+  - mail@stephan-plarre.de
+  - nic@neanderfunk.de
+networks:
+  ipv4:
+    - 10.1.192.0/18
+  ipv6:
+    - fdd9:a0b1:5bd0::/48

--- a/ratingen
+++ b/ratingen
@@ -1,0 +1,11 @@
+# This is your ASN.
+asn: 64867
+tech-c:
+  - freifunk@benedikt-wildenhain.de
+  - mail@stephan-plarre.de
+  - nic@neanderfunk.de
+networks:
+  ipv4:
+    - 10.11.64.0/20
+  ipv6:
+    - fde0:105b:1d87::/48

--- a/velbert
+++ b/velbert
@@ -1,0 +1,11 @@
+# This is your ASN.
+asn: 64870
+tech-c:
+  - freifunk@benedikt-wildenhain.de
+  - mail@stephan-plarre.de
+  - nic@neanderfunk.de
+networks:
+  ipv4:
+    - 10.11.80.0/20
+  ipv6:
+    - fdc8:08a2:b198::/48


### PR DESCRIPTION
Die o.g. Städte sind bisher Teil der Rheinufer-Domäne. Diese ist aber zu groß geworden und kann daher keine weiteren Nodes aufnehmen. Daher sollen nun eigenständige Broadcast-Domänen für diese Städte entstehen.