### PR TITLE
Update Freifunk Saar Eintrag

### DIFF
--- a/saar
+++ b/saar
@@ -6,8 +6,10 @@ tech-c:
 networks:
   ipv4:
     - 10.24.192.0/18
+    - 10.252.64.0/18
   ipv6:
     - fd4e:f2d7:88d2:ffff::/64
+    - fd4e:f2d7:88d2:fffd::/64
 
 #bgp:
 # Not participating in the IC-VPN yet!
@@ -15,14 +17,12 @@ networks:
 domains:
   - ffsaar
   - f.f.f.f.2.d.8.8.7.d.2.f.e.4.d.f.ip6.arpa
+  - d.f.f.f.2.d.8.8.7.d.2.f.e.4.d.f.ip6.arpa
   - 192/18.24.10.in-addr.arpa
+  - 64/18.252.10.in-addr.arpa
 
 nameservers:
   - 10.24.192.2
   - 10.24.192.3
-  - 10.24.192.4
-  - 10.24.192.5
   - fd4e:f2d7:88d2:ffff::2
   - fd4e:f2d7:88d2:ffff::3
-  - fd4e:f2d7:88d2:ffff::4
-  - fd4e:f2d7:88d2:ffff::5


### PR DESCRIPTION
Zusätzliche (Test-)IP-Netze hinzugefügt und alte Gateways aus den Nameservern entfernt.