### PR TITLE
change ASN and IPv4

### DIFF
--- a/bochum
+++ b/bochum
@@ -1,8 +1,8 @@
 tech-c:
   - info@freifunk-bochum.de
-asn: 65408
+asn: 65110
 networks:
   ipv4:
-    - 10.110.0.0/18
+    - 10.110.0.0/16
   ipv6:
     - 2a03:2260:300b::/48


### PR DESCRIPTION
Bochum zieht vom Ruhrgebiet um. In diesem Rahmen wechseln wir während der Parallelbereitstellung die Netze und geben das alte Netz dann ab, sobald alles Funktionsfähig ist.

Das /18 IPv4 Netz ist zu knapp für unser geplantes Setup. Jede Supernode sollte bis zu 2500 Adressen verteilen können. Der Adressraum ist bereits jetzt  erschöpft. Es kommen aber noch zwei große Bleche mit VMs hinzu. Es zeichnet sich bereits jetzt ab, dass die Idee ein kleineres Netz zu nutzen bei unseren Plänen ziemlich dämlich war. Bochum wird das 10.226.0.0/16 Netz, dass zur Zeit im FFRG angegliedert ist nach Umstellung abgeben. Es handelt sich also lediglich um einen Wechsel und ein Rückrudern von der Idee ein kleineres Netz zu wählen. Das ist vom Setup her unnützer Pain.

Die ASN wird geändert, damit Probleme während der Parallelumstellung minimiert werden. FFRG-Bochum und Bochum Announcen sonst das gleiche AS. Wir haben noch verschwindende Verbindungen und wollen die ASN als Fehlerquelle ausschließen. Deshalb hier eine neue und im RG (bis zur Abschaltung) die Alte