### PR TITLE
Create bochumrg

### DIFF
--- a/bochumrg
+++ b/bochumrg
@@ -1,0 +1,4 @@
+
+tech-c:
+  - kontakt@freifunk-ruhrgebiet.de
+asn: 65408


### PR DESCRIPTION
Bochum wechselt vom ffrg zu einem eigenen Netz. In diesem Zuge werden um Probleme wärend des Umzugs zu vermeiden neue IP Netze sowie eine neue ASN verwendet. Dies ist der alte Eintrag des Bochum Netzes innerhalb des FFRG. Er ist nur temprorär und soll Konflikte während des Netzaufbaus und der Parallelbereitstellung verhindern.