### PR TITLE
Added Transfer-Net directive for kbu-test

### DIFF
--- a/kbu
+++ b/kbu
@@ -8,6 +8,8 @@ networks:
   ipv6:
     - fdd3:5d16:b5dd::/48
 bgp:
+  kbutest:
+    ipv6: fec0::a:cf:0:60
   koeln1:
     ipv4: 10.207.0.57
     ipv6: fec0::a:cf:0:57


### PR DESCRIPTION
fec0::a:cf:0:60 geht an den Testserver