### PR TITLE
kbutest an findfree-Ausgabe angepasst

### DIFF
--- a/kbu
+++ b/kbu
@@ -9,7 +9,8 @@ networks:
     - fdd3:5d16:b5dd::/48
 bgp:
   kbutest:
-    ipv6: fec0::a:cf:0:60
+    ipv6: fec0::a:cf:0:2a
+    ipv4: 10.207.0.42
   koeln1:
     ipv4: 10.207.0.57
     ipv6: fec0::a:cf:0:57


### PR DESCRIPTION
IPv4-Peering Tests.

findfree sagt: 
```shell
# /opt/icvpn-scripts/findfree 
asn: [64879, 64882, 64883, 64884, 64885]
subnets: [10.11.176.0/20, 10.11.192.0/20, 10.11.208.0/20, 10.11.224.0/20, 10.11.240.0/20]
transfer:
- [10.207.0.42, 'fec0::a:cf:0:2a']
- [10.207.0.50, 'fec0::a:cf:0:32']
- [10.207.0.60, 'fec0::a:cf:0:3c']
- [10.207.0.62, 'fec0::a:cf:0:3e']
- [10.207.0.67, 'fec0::a:cf:0:43']
```

Also nehmen wir mal `10.207.0.42`, `fec0::a:cf:0:2a`
