### PR TITLE
Delete bochumrg

### DIFF
--- a/bochumrg
+++ b/bochumrg
@@ -1,4 +1,0 @@
-
-tech-c:
-  - kontakt@freifunk-ruhrgebiet.de
-asn: 65408


### PR DESCRIPTION
Der Umzug ist abgeschlossen Bochum ist nicht mehr Teil der RG Domäne und läuft nur noch über das neue AS. Der Eintrag kann gelöscht werden.