### PR TITLE
prepend bgp-names with location

### DIFF
--- a/foerdefunk-flensburg
+++ b/foerdefunk-flensburg
@@ -8,9 +8,9 @@ networks:
   ipv6:
     - fdff:49:461::/48
 bgp:
-  schleuse01:
+  flensburg_foer_schleuse01:
     ipv4: 10.207.0.65
     ipv6: fec0::a:cf:0:41
-  schleuse02:
+  flensburg_foer_schleuse02:
     ipv4: 10.207.0.66
     ipv6: fec0::a:cf:0:42

--- a/hameln
+++ b/hameln
@@ -25,7 +25,7 @@ domains:
   - 110.11.10.in-addr.arpa
   - 111.11.10.in-addr.arpa
 bgp:
-  ffhmgw01:
+  hameln_ffhmgw01:
     ipv4: 10.207.0.31
     ipv6: fec0::a:cf:0:1f
 nameservers:

--- a/heiligkreuztal
+++ b/heiligkreuztal
@@ -10,6 +10,6 @@ networks:
     - fd0c:9a97:47dc::/48
 
 bgp:
-  hkt01:
+  heiligkreuztal_hkt01:
     ipv4: 10.207.0.4
     ipv6: fec0::a:cf:0:4

--- a/innsbruck
+++ b/innsbruck
@@ -8,9 +8,9 @@ networks:
     - fd13:b4dc:4b1e::/64
     - fd14:b4dc:4b1e::/64
 bgp:
-  ffibk1:
+  innsbruck_ffibk1:
     ipv4: 10.207.0.67
     ipv6: fec0::a:cf:0:43
-  ffibk2:
+  innsbruck_ffibk2:
     ipv4: 10.207.0.69
     ipv6: fec0::a:cf:0:45

--- a/mainz
+++ b/mainz
@@ -7,13 +7,13 @@ networks:
   ipv6:
     - fd37:b4dc:4b1e::/48
 bgp:
-  mwu7:
+  mainz_mwu7:
     ipv4: 10.207.1.37
     ipv6: fec0::a:cf:1:25
-  mwu231:
+  mainz_mwu231:
     ipv4: 10.207.0.37
     ipv6: fec0::a:cf:0:25
-  mwu161:
+  mainz_mwu161:
     ipv4: 10.207.37.161
     ipv6: fec0::a:cf:25:a1
 domains:

--- a/mayen-koblenz
+++ b/mayen-koblenz
@@ -3,13 +3,13 @@ tech-c:
   - freifunk@adlerweb.info
 asn: 65032
 bgp:
-  myk1:
+  mayen_koblenz_myk1:
     ipv4: 10.207.0.80
     ipv6: fec0::a:cf:0:50
-  myk2:
+  mayen_koblenz_myk2:
     ipv4: 10.207.0.81
     ipv6: fec0::a:cf:0:51
-  myk3:
+  mayen_koblenz_myk3:
     ipv4: 10.207.0.82
     ipv6: fec0::a:cf:0:52
 networks:

--- a/rheinsiegkreis
+++ b/rheinsiegkreis
@@ -7,6 +7,6 @@ networks:
   ipv6:
     - fda0:747e:ab29:2241::/64
 bgp:
-  rsk1:
+  rheinsiegkreis_rsk1:
     ipv4: 10.207.0.111
     ipv6: fec0::a:cf:0:6f

--- a/uelzen
+++ b/uelzen
@@ -7,7 +7,7 @@ networks:
   ipv6:
     - fd83:e002:c8a1::/48
 bgp:
-  uegw1: 
+  uelzen_uegw1: 
     ipv4: 10.207.0.18
     ipv6: fec0::a:cf:0:12
 domains:

--- a/weststeiermark
+++ b/weststeiermark
@@ -5,5 +5,5 @@ networks:
   ipv4:
     - 10.51.0.0/16
 bgp:
-  schilcher1:
+  weststeiermark_schilcher1:
     ipv4: 10.207.0.51

--- a/wiesbaden
+++ b/wiesbaden
@@ -7,7 +7,7 @@ networks:
   ipv6:
     - fd56:b4dc:4b1e::/48
 bgp:
-  mwu23:
+  wiesbaden_mwu23:
     ipv4: 10.207.0.56
     ipv6: fec0::a:cf:0:38
 domains:


### PR DESCRIPTION
Because some names are to generic to be usefull. Now for every bgp-name it should be clear which file is responsible for this bgp-server.