### PR TITLE
ffmd: change contact address

### DIFF
--- a/magdeburg
+++ b/magdeburg
@@ -1,5 +1,5 @@
 tech-c:
-  - andreas@netz39.de
+  - kontakt@md.freifunk.net
 asn: 65039
 networks:
   ipv4:


### PR DESCRIPTION
Andreas left the Freifunk Magdeburg project. Until we have a new
technical contact person, we set the address to the generic one.

Signed-off-by: Alexander Dahl <alex@netz39.de>