### PR TITLE
Helgoland: Nameserverumzug von srv01 zu srv02

### DIFF
--- a/helgoland
+++ b/helgoland
@@ -9,5 +9,5 @@ domains:
   - helgo
   - 189.10.in-addr.arpa
 nameservers:
-  - 10.112.1.1
-  - 2a03:2267::101
+  - 10.112.1.2
+  - 2a03:2267::102


### PR DESCRIPTION
Analog zu #492, diesmal weiß @entil-zha Bescheid.