### PR TITLE
franken: Add domain for ipv6 reverse dns

### DIFF
--- a/franken
+++ b/franken
@@ -21,6 +21,7 @@ domains:
   - fff.community
   - 50.10.in-addr.arpa
   - 83.10.in-addr.arpa
+  - d.b.9.2.2.0.6.5.3.4.d.f.ip6.arpa
 
 nameservers:
   - fd43:5602:29bd:ffff::252


### PR DESCRIPTION
The nameservers of Freifunk Franken are also capable of doing
IPv6 reverse lookups for the IPv6 ULA range, so the appropriate
reverse dns domain is added.

Signed-off-by: Fabian Bläse <fabian@blaese.de>