### PR TITLE
Remove TLD rzl.

### DIFF
--- a/rzl
+++ b/rzl
@@ -1,4 +1,0 @@
-domains:
- - rzl
-nameservers:
- - 172.22.36.1


### PR DESCRIPTION
The TLD `rzl.` has been removed from the dn42 registry 9 months ago (https://git.dn42.dev/dn42/registry/pulls/1720). Explanation in the dn42 PR:
> Drops the rzl. TLD which has been dysfunctional on DN42 for a while now and has been dropped from internal use now too.