### PR TITLE
hochstift: Remove BGP/DNS info, keep prefixes for the record

### DIFF
--- a/hochstift
+++ b/hochstift
@@ -6,17 +6,3 @@ networks:
     - 10.132.0.0/16
   ipv6:
     - 2a03:2260:2342::/48
-bgp:
-  ffho01:
-    ipv4: 10.207.0.231
-    ipv6: fec0::a:cf:0:e7
-  ffho02:
-    ipv4: 10.207.0.232
-    ipv6: fec0::a:cf:0:e8
-domains:
-  - ffho.net
-  - 132.10.in-addr.arpa
-  - 2.4.3.2.0.6.2.2.3.0.a.2.ip6.arpa
-nameservers:
-  - 10.132.251.53
-  - 2a03:2260:2342:f251::53


### PR DESCRIPTION
We'Ve not been connected to ICVNP for a while and likely won't be in the near future, so remove BGP and DNS configuration to remove noise for others. We'll let the prefixes stay so they keep being on the record.